### PR TITLE
1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ task publishDiluv (type: TaskDiluvUpload){
 | releaseType    | false    | The release status of the file. Defaults to "alpha".                             |
 | classifier     | false    | The type of file being uploaded. Defaults to binary.                             |
 | gameVersion    | true     | The version of the game the file is for. Comma separated for multiple.           |
+| failSilently   | false    | When true an upload failure will not fail your build.                            |
+
+**Note:** In some scenarios the `gameVersion` property can be detected automatically. For example the ForgeGradle and LoomGradle environments. For best results you should set this property manually.
 
 ### Additional Properties
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'signing'
     id 'io.codearte.nexus-staging' version '0.22.0'
     id "de.marcphilipp.nexus-publish" version "0.4.0"
+    id "com.gradle.plugin-publish" version "0.12.0"
+    id "java-gradle-plugin"
 }
 
 version = "${project_version}"
@@ -31,6 +33,28 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+gradlePlugin {
+    plugins {
+        diluvPlugin {
+            id = 'org.diluv.diluvgradle'
+            implementationClass = 'com.diluv.diluvgradle.DiluvPlugin'
+        }
+    }
+}
+
+pluginBundle {
+    website = 'https://diluv.com'
+    vcsUrl = 'https://github.com/Diluv/Diluv-Gradle'
+    description = 'Diluv plugin for uploading your build artifacts!'
+    tags = ['diluv', 'publish', 'mods', 'minecraft']
+
+    plugins {
+        diluvGradle {
+            displayName = 'DiluvGradle'
+        }
+    }
 }
 
 jar {

--- a/src/main/java/com/diluv/diluvgradle/DiluvPlugin.java
+++ b/src/main/java/com/diluv/diluvgradle/DiluvPlugin.java
@@ -1,0 +1,13 @@
+package com.diluv.diluvgradle;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class DiluvPlugin implements Plugin<Project> {
+    
+    @Override
+    public void apply (Project project) {
+        
+        project.getLogger().debug("Successfully applied the Diluv plugin. Make sure you're using the upload task.");
+    }
+}

--- a/src/main/java/com/diluv/diluvgradle/TaskDiluvUpload.java
+++ b/src/main/java/com/diluv/diluvgradle/TaskDiluvUpload.java
@@ -93,6 +93,11 @@ public class TaskDiluvUpload extends DefaultTask {
     public String gameVersion;
     
     /**
+     * Allows build to continue even if the upload failed.
+     */
+    public boolean failSilently = false;
+    
+    /**
      * The response from the API when the file was uploaded successfully.
      */
     @Nullable
@@ -118,60 +123,77 @@ public class TaskDiluvUpload extends DefaultTask {
     @TaskAction
     public void apply () {
         
-        // Attempt to automatically resolve the game version if one wasn't specified.
-        if (this.gameVersion == null) {
-            
-            this.gameVersion = detectGameVersion(this.getProject());
-        }
-        
-        // Use project version if no version is specified.
-        if (this.projectVersion == null) {
-            
-            this.projectVersion = this.getProject().getVersion().toString();
-        }
-        
-        // Only semantic versioning is allowed.
-        if (!SEM_VER.matcher(this.projectVersion).matches()) {
-            
-            this.getProject().getLogger().error("Project version {} is not semantic versioning compatible. The file can not be uploaded. https://semver.org", this.projectVersion);
-            throw new GradleException("Project version '" + this.projectVersion + "' is not semantic versioning compatible. The file can not be uploaded. https://semver.org");
-        }
-        
-        // Set a default changelog if the dev hasn't provided one.
-        if (this.changelog == null) {
-            
-            this.changelog = "The project has been updated to " + this.getProject() + ". No changelog was specified.";
-        }
-        
-        final File file = resolveFile(this.getProject(), this.uploadFile, null);
-        
-        // Ensure the file actually exists before trying to upload it.
-        if (file == null || !file.exists()) {
-            
-            this.getProject().getLogger().error("The upload file is missing or null. {}", this.uploadFile);
-            throw new GradleException("The upload file is missing or null. " + String.valueOf(this.uploadFile));
-        }
-        
         try {
             
-            final URI endpoint = new URI(this.getUploadEndpoint());
+            // Attempt to automatically resolve the game version if one wasn't specified.
+            if (this.gameVersion == null) {
+                
+                this.gameVersion = detectGameVersion(this.getProject());
+            }
+            
+            // Use project version if no version is specified.
+            if (this.projectVersion == null) {
+                
+                this.projectVersion = this.getProject().getVersion().toString();
+            }
+            
+            // Only semantic versioning is allowed.
+            if (!SEM_VER.matcher(this.projectVersion).matches()) {
+                
+                this.getProject().getLogger().error("Project version {} is not semantic versioning compatible. The file can not be uploaded. https://semver.org", this.projectVersion);
+                throw new GradleException("Project version '" + this.projectVersion + "' is not semantic versioning compatible. The file can not be uploaded. https://semver.org");
+            }
+            
+            // Set a default changelog if the dev hasn't provided one.
+            if (this.changelog == null) {
+                
+                this.changelog = "The project has been updated to " + this.getProject() + ". No changelog was specified.";
+            }
+            
+            final File file = resolveFile(this.getProject(), this.uploadFile, null);
+            
+            // Ensure the file actually exists before trying to upload it.
+            if (file == null || !file.exists()) {
+                
+                this.getProject().getLogger().error("The upload file is missing or null. {}", this.uploadFile);
+                throw new GradleException("The upload file is missing or null. " + String.valueOf(this.uploadFile));
+            }
             
             try {
                 
-                this.upload(endpoint, file);
+                final URI endpoint = new URI(this.getUploadEndpoint());
+                
+                try {
+                    
+                    this.upload(endpoint, file);
+                }
+                
+                catch (final IOException e) {
+                    
+                    this.getProject().getLogger().error("Failed to upload the file!", e);
+                    throw new GradleException("Failed to upload the file!", e);
+                }
             }
             
-            catch (final IOException e) {
+            catch (final URISyntaxException e) {
                 
-                this.getProject().getLogger().error("Failed to upload the file!", e);
-                throw new GradleException("Failed to upload the file!", e);
+                this.getProject().getLogger().error("Invalid endpoint URI!", e);
+                throw new GradleException("Invalid endpoint URI!", e);
             }
         }
         
-        catch (final URISyntaxException e) {
+        catch (final Exception e) {
             
-            this.getProject().getLogger().error("Invalid endpoint URI!", e);
-            throw new GradleException("Invalid endpoint URI!", e);
+            if (this.failSilently) {
+                
+                this.getLogger().info("Failed to upload to Diluv. Check logs for more info.");
+                this.getLogger().error("Diluv upload failed silently.", e);
+            }
+            
+            else {
+                
+                throw e;
+            }
         }
     }
     

--- a/src/main/java/com/diluv/diluvgradle/TaskDiluvUpload.java
+++ b/src/main/java/com/diluv/diluvgradle/TaskDiluvUpload.java
@@ -129,6 +129,11 @@ public class TaskDiluvUpload extends DefaultTask {
             if (this.gameVersion == null) {
                 
                 this.gameVersion = detectGameVersion(this.getProject());
+                
+                if (this.gameVersion == null) {
+                    
+                    throw new GradleException("Can not upload to Diluv. gameVersion is null and could not be detected.");
+                }
             }
             
             // Use project version if no version is specified.

--- a/src/main/java/com/diluv/diluvgradle/responses/ResponseUpload.java
+++ b/src/main/java/com/diluv/diluvgradle/responses/ResponseUpload.java
@@ -170,11 +170,11 @@ public class ResponseUpload {
     }
     
     public static class GameVersion {
-
+        
         @Expose
         @SerializedName("version")
         private String version;
-
+        
         @Expose
         @SerializedName("type")
         private String type;


### PR DESCRIPTION
- Adds support for autodetecting Minecraft version when using the LoomGradle plugin.
- Add baseline support for being used as a plugin.
- Added `failSilently` option to allow ignoring upload failures. 
- Added fail state for when game version is null and can't be detected. 